### PR TITLE
fixed room password protection and other fixes...

### DIFF
--- a/src/handlers/chathandler.ts
+++ b/src/handlers/chathandler.ts
@@ -98,7 +98,7 @@ export class ChatHandler {
         const targetsession: UserSession = receiverConn.session
 
         const outMsgData: OutChatPacket = OutChatPacket.directMessage(
-            session.user.playerName, session.user.vipLevel, session.user.gm,
+            session.user.playerName, session.user.vipLevel, targetsession.user.gm,
             targetsession.user.playerName, false, chatPkt.message)
         conn.send(outMsgData)
 

--- a/src/handlers/roomhandler.ts
+++ b/src/handlers/roomhandler.ts
@@ -163,7 +163,7 @@ export class RoomHandler {
             return false
         }
 
-        if (desiredRoom.isPasswordRight(joinReq.roomPassword) === false) {
+        if (!desiredRoom.isPasswordRight('') && desiredRoom.isPasswordRight(joinReq.roomPassword) === false) {
             const roomMsg = '#CSO2_POPUP_ROOM_JOIN_FAILED_INVALID_PASSWD'
 
             const sysDialog: OutChatPacket = OutChatPacket.systemMessage(roomMsg, ChatMessageType.DialogBox)

--- a/src/handlers/roomhandler.ts
+++ b/src/handlers/roomhandler.ts
@@ -107,6 +107,7 @@ export class RoomHandler {
             killLimit: newRoomReq.killLimit,
             mapId: newRoomReq.mapId,
             roomName: newRoomReq.roomName,
+            roomPassword: newRoomReq.roomPassword,
             winLimit: newRoomReq.winLimit,
         })
 
@@ -159,6 +160,18 @@ export class RoomHandler {
 
             console.warn('user ID %i tried to join a full room. room name "%s" room id: %i',
                 session.user.userId, desiredRoom.settings.roomName, desiredRoom.id)
+            return false
+        }
+
+        if (desiredRoom.isPasswordRight(joinReq.roomPassword) === false) {
+            const roomMsg = '#CSO2_POPUP_ROOM_JOIN_FAILED_INVALID_PASSWD'
+
+            const sysDialog: OutChatPacket = OutChatPacket.systemMessage(roomMsg, ChatMessageType.DialogBox)
+            sourceConn.send(sysDialog)
+
+            console.warn('user ID %i tried to join a password protected room with wrong password "%s", really password: "%s". room name "%s" room id: %i', session.user.userId,
+                joinReq.roomPassword, desiredRoom.settings.roomPassword,
+                desiredRoom.settings.roomName, desiredRoom.id)
             return false
         }
 
@@ -347,6 +360,11 @@ export class RoomHandler {
         }
 
         if (currentRoom.isUserReady(session.user.userId)) {
+            const roomMsg = '#CSO2_POPUP_ROOM_CHANGETEAM_FAILED'
+
+            const sysMessage: OutChatPacket = OutChatPacket.systemMessage(roomMsg, ChatMessageType.System)
+            sourceConn.send(sysMessage)
+
             console.warn('user ID %i tried change team in a room, although it\'s ready. room name "%s" room id: %i',
                 session.user.userId, currentRoom.settings.roomName, currentRoom.id)
             return false
@@ -399,6 +417,11 @@ export class RoomHandler {
         const count: number = countdownReq.count
 
         if (currentRoom.canStartGame() === false) {
+            const roomMsg = '#CSO2_UI_ROOM_COUNTDOWN_FAILED_NOENEMY'
+
+            const sysMessage: OutChatPacket = OutChatPacket.systemMessage(roomMsg, ChatMessageType.System)
+            sourceConn.send(sysMessage)
+
             console.warn('user ID %i tried to toggle a room\'s game start countdown, although it can\'t start. '
                 + 'room name "%s" room id: %i',
                 session.user.userId, currentRoom.settings.roomName, currentRoom.id)

--- a/src/handlers/roomhandler.ts
+++ b/src/handlers/roomhandler.ts
@@ -8,12 +8,16 @@ import { Room, RoomReadyStatus, RoomStatus } from 'room/room'
 
 import { UserSession } from 'user/usersession'
 
+import { ChatMessageType } from 'packets/definitions'
+
 import { InRoomPacket, InRoomType } from 'packets/in/room'
 import { InRoomCountdown } from 'packets/in/room/countdown'
 import { InRoomNewRequest } from 'packets/in/room/fullrequest'
 import { InRoomJoinRequest } from 'packets/in/room/joinrequest'
 import { InRoomSetUserTeamRequest } from 'packets/in/room/setuserteamreq'
 import { InRoomUpdateSettings } from 'packets/in/room/updatesettings'
+
+import { OutChatPacket } from 'packets/out/chat'
 
 export class RoomHandler {
     /**
@@ -137,12 +141,22 @@ export class RoomHandler {
         const desiredRoom: Room = channel.getRoomById(joinReq.roomId)
 
         if (desiredRoom == null) {
+            const roomMsg = '#CSO2_POPUP_ROOM_JOIN_FAILED_CLOSED'
+
+            const sysDialog: OutChatPacket = OutChatPacket.systemMessage(roomMsg, ChatMessageType.DialogBox)
+            sourceConn.send(sysDialog)
+
             console.warn('user ID %i tried to join a non existing room. room id: %i',
                 session.user.userId, joinReq.roomId)
             return false
         }
 
         if (desiredRoom.hasFreeSlots() === false) {
+            const roomMsg = '#CSO2_POPUP_ROOM_JOIN_FAILED_FULL'
+
+            const sysDialog: OutChatPacket = OutChatPacket.systemMessage(roomMsg, ChatMessageType.DialogBox)
+            sourceConn.send(sysDialog)
+
             console.warn('user ID %i tried to join a full room. room name "%s" room id: %i',
                 session.user.userId, desiredRoom.settings.roomName, desiredRoom.id)
             return false

--- a/src/packets/definitions.ts
+++ b/src/packets/definitions.ts
@@ -47,4 +47,5 @@ export enum ChatMessageType {
     SystemImportant = 20,
     DialogBox = 21, // note: has not 'Yes' and 'No' select option
     System = 22,
+    DialogBoxExit = 60, // when client clicked 'OK', the game will exit (text start with '#CSO2_POPUP_')
 }

--- a/src/packets/in/room/fullrequest.ts
+++ b/src/packets/in/room/fullrequest.ts
@@ -15,7 +15,7 @@ export class InRoomNewRequest {
     public unk02: number
     public unk03: number
     public unk04: number
-    public unk05: string
+    public roomPassword: string
     public unk06: number
     public unk07: number
     public unk08: number
@@ -34,7 +34,7 @@ export class InRoomNewRequest {
         this.unk02 = inPacket.readUInt8()
         this.unk03 = inPacket.readUInt8()
         this.unk04 = inPacket.readUInt8()
-        this.unk05 = inPacket.readString()
+        this.roomPassword = inPacket.readString()
         this.unk06 = inPacket.readUInt8()
         this.unk07 = inPacket.readUInt8()
         this.unk08 = inPacket.readUInt8()

--- a/src/packets/in/room/joinrequest.ts
+++ b/src/packets/in/room/joinrequest.ts
@@ -6,10 +6,10 @@ import { InPacketBase } from 'packets/in/packet'
  */
 export class InRoomJoinRequest {
     public roomId: number
-    public password: string // unconfirmed
+    public roomPassword: string
 
     constructor(inPacket: InPacketBase) {
-        this.roomId = inPacket.readUInt8()
-        this.password = inPacket.readLongString()
+        this.roomId = inPacket.readUInt16()
+        this.roomPassword = inPacket.readString()
     }
 }

--- a/src/packets/in/room/updatesettings.ts
+++ b/src/packets/in/room/updatesettings.ts
@@ -16,7 +16,7 @@ export class InRoomUpdateSettings {
     public unk02: number
     public unk03: number
     // flags & 0x8
-    public unk09: string
+    public roomPassword: string
     // end of flags & 0x8
     // flags & 0x10
     public unk10: number
@@ -153,7 +153,7 @@ export class InRoomUpdateSettings {
             this.unk03 = inPacket.readUInt32()
         }
         if (lowFlag & 0x8) {
-            this.unk09 = inPacket.readString()
+            this.roomPassword = inPacket.readString()
         }
         if (lowFlag & 0x10) {
             this.unk10 = inPacket.readUInt16()

--- a/src/packets/out/room/updatesettings.ts
+++ b/src/packets/out/room/updatesettings.ts
@@ -23,7 +23,7 @@ export class OutRoomUpdateSettings {
         if (settings.unk01 != null && settings.unk02 != null && settings.unk03 != null) {
             lowFlag |= 0x4
         }
-        if (settings.unk09 != null) {
+        if (settings.roomPassword != null) {
             lowFlag |= 0x8
         }
         if (settings.unk10 != null) {
@@ -171,7 +171,7 @@ export class OutRoomUpdateSettings {
             outPacket.writeUInt32(settings.unk03)
         }
         if (lowFlag & 0x8) {
-            outPacket.writeString(settings.unk09)
+            outPacket.writeString(settings.roomPassword)
         }
         if (lowFlag & 0x10) {
             outPacket.writeUInt16(settings.unk10)

--- a/src/packets/out/roomlist/item.ts
+++ b/src/packets/out/roomlist/item.ts
@@ -32,7 +32,7 @@ export class RoomListItem {
         outPacket.writeUInt8(this.room.id) // roomNumber
         // end flags & 0x2
         // flags & 0x4
-        outPacket.writeUInt8(0) // passwordProtected
+        outPacket.writeUInt8(this.room.isPasswordRight('') ? 0 : 1) // passwordProtected
         // end flags & 0x4
         // flags & 0x8
         outPacket.writeUInt16(0) // unk03

--- a/src/packets/out/userinfo/fulluserupdate.ts
+++ b/src/packets/out/userinfo/fulluserupdate.ts
@@ -48,7 +48,7 @@ export class UserInfoFullUpdate {
 
         // flag & 0x40
         outPacket.writeUInt32(user.playedMatches) // played game
-        outPacket.writeUInt32(user.wins) // wins (win rate = wins / player game)
+        outPacket.writeUInt32(user.wins) // wins (win rate = wins / played game)
         outPacket.writeUInt32(user.kills) // kills
         outPacket.writeUInt32(user.headshots) // headshots (hs rate = hs / kills)
         outPacket.writeUInt32(user.deaths) // deaths

--- a/src/room/room.ts
+++ b/src/room/room.ts
@@ -701,6 +701,9 @@ export class Room {
         if (newSettings.roomName != null) {
             this.settings.roomName = newSettings.roomName
         }
+        if (newSettings.roomPassword != null) {
+            this.settings.roomPassword = newSettings.roomPassword
+        }
         if (newSettings.gameModeId != null) {
             this.settings.gameModeId = newSettings.gameModeId
         }
@@ -763,9 +766,6 @@ export class Room {
         }
         if (newSettings.unk03 != null) {
             this.settings.unk03 = newSettings.unk03
-        }
-        if (newSettings.unk09 != null) {
-            this.settings.unk09 = newSettings.unk09
         }
         if (newSettings.unk10 != null) {
             this.settings.unk10 = newSettings.unk10

--- a/src/room/room.ts
+++ b/src/room/room.ts
@@ -18,6 +18,7 @@ export enum RoomTeamNum {
     Unknown = 0,
     Terrorist = 1,
     CounterTerrorist = 2,
+    Spectator = 3,
 }
 
 export enum RoomReadyStatus {
@@ -106,6 +107,7 @@ export enum RoomTeamBalance {
 
 export interface IRoomOptions {
     roomName?: string,
+    roomPassword?: string,
     gameModeId?: number,
     mapId?: number,
     winLimit?: number,
@@ -209,6 +211,15 @@ export class Room {
      */
     public hasFreeSlots(): boolean {
         return this.getFreeSlots() !== 0
+    }
+
+    /**
+     * did the user typed the correct password?
+     * @param password the password we need to check
+     * @returns true the password is matches, false if not
+     */
+    public isPasswordRight(password: string): boolean {
+        return this.settings.roomPassword === password
     }
 
     /**

--- a/src/room/roomsettings.ts
+++ b/src/room/roomsettings.ts
@@ -2,6 +2,7 @@ import { IRoomOptions, RoomGamemode, RoomStatus, RoomTeamBalance } from 'room/ro
 
 export class RoomSettings {
     public roomName: string
+    public roomPassword: string
     public maxPlayers: number
     public gameModeId: RoomGamemode
     public mapId: number
@@ -29,7 +30,6 @@ export class RoomSettings {
     public unk01: number
     public unk02: number
     public unk03: number
-    public unk09: string
     public unk10: number
     public unk13: number
     public unk17: number
@@ -56,6 +56,7 @@ export class RoomSettings {
         }
 
         this.roomName = options.roomName ? options.roomName : 'Some room'
+        this.roomPassword = options.roomPassword ? options.roomPassword : ''
         this.gameModeId = options.gameModeId ? options.gameModeId : 0
         this.mapId = options.mapId ? options.mapId : 1
         this.winLimit = options.winLimit ? options.winLimit : 10

--- a/src/user/usermanager.ts
+++ b/src/user/usermanager.ts
@@ -262,6 +262,11 @@ room but it couldn't be found.`)
             return false
         }
 
+        if (teamData.newTeam !== 1 && teamData.newTeam !== 2) {
+            console.warn(`User Id ${targetSession.user.userId} tried to change his team, but the value ${teamData.newTeam} is not allowed.`)
+            return false
+        }
+
         currentRoom.updateUserTeam(targetSession.user.userId, teamData.newTeam)
 
         console.log('Automatic changing User ID %i\'s team to the %i in room %s (host ID %i, room id %i)',

--- a/src/user/usermanager.ts
+++ b/src/user/usermanager.ts
@@ -105,8 +105,12 @@ export class UserManager {
         const loggedUserId = await userService.Login(loginPacket.gameUsername, loginPacket.password)
 
         if (loggedUserId === 0) {
+            const badCredsMsg = '#CSO2_LoginAuth_Certify_NoPassport'
+
+            const badDialogData: OutChatPacket = OutChatPacket.systemMessage(badCredsMsg, ChatMessageType.DialogBox)
+            connection.send(badDialogData)
+
             console.warn('Could not create session for user %s', loginPacket.gameUsername)
-            connection.end()
             return false
         }
 
@@ -126,8 +130,12 @@ export class UserManager {
         const user: User = await userService.GetUserById(loggedUserId)
 
         if (user == null) {
+            const badInfoMsg = '#CSO2_ServerMessage_INVALID_USERINFO'
+
+            const badDialogData: OutChatPacket = OutChatPacket.systemMessage(badInfoMsg, ChatMessageType.DialogBox)
+            connection.send(badDialogData)
+
             console.error('Couldn\'t get user ID %i\' information', loggedUserId)
-            connection.end()
             return false
         }
 

--- a/src/user/usermanager.ts
+++ b/src/user/usermanager.ts
@@ -4,7 +4,7 @@ import superagent from 'superagent'
 import { ExtendedSocket } from 'extendedsocket'
 
 import { Channel } from 'channel/channel'
-import { Room } from 'room/room'
+import { Room, RoomTeamNum } from 'room/room'
 
 import { User } from 'user/user'
 import { UserInventory } from 'user/userinventory'
@@ -270,7 +270,7 @@ room but it couldn't be found.`)
             return false
         }
 
-        if (teamData.newTeam !== 1 && teamData.newTeam !== 2) {
+        if (teamData.newTeam !== RoomTeamNum.Terrorist && teamData.newTeam !== RoomTeamNum.CounterTerrorist) {
             console.warn(`User Id ${targetSession.user.userId} tried to change his team, but the value ${teamData.newTeam} is not allowed.`)
             return false
         }


### PR DESCRIPTION
user can use password to protect they room now. fixed https://github.com/L-Leite/cso2-master-server/issues/51

send the error message when user doing something wrong:
1. login failed (can't get userinfo from user-services)
2. joining a non-exist/full room, typed wrong password
3. change team in room but has ready status, start game with no enemy

added a new system message type: "DialogBoxExit". the client will auto-exit the game when user clicked "OK" from this message type. (**used when detected cheats, server maintenance etc...**)
note: this type's message will start with "#CSO2_POPUP_" (has localization support), you can use the custom message but you can't delete this text (client things...) and you will lose the localization support if you are using custom message (start with "\n\n\n\n\n" may solve this problem? haha)